### PR TITLE
Update Dockerfile: fix build.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./docker/zerotier/Dockerfile
       args:
-        - ZEROTIER_VERSION=1.8.6
+        - ZEROTIER_VERSION=1.10.0
         - CHINA_SOURCE=true
         # - http_proxy=http://172.17.0.1:10809
         # - https_proxy=http://172.17.0.1:10809
@@ -26,7 +26,7 @@ services:
       context: .
       dockerfile: ./docker/zero-ui/Dockerfile
       args:
-        - ZEROUI_VERSION=1.2.1
+        - ZEROUI_VERSION=1.4.1
     restart: unless-stopped
     depends_on:
       - zerotier

--- a/docker/zerotier/Dockerfile
+++ b/docker/zerotier/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache curl g++ && \
     sed -i '85i roots.push_back(World::Root());' ./mkworld.cpp && \
     sed -i '86i roots.back().identity = Identity(\"'"$identity"'\");' ./mkworld.cpp && \
     sed -i '87i roots.back().stableEndpoints.push_back(InetAddress(\"'"$addr"'\"));' ./mkworld.cpp && \
-    sed -i 's/c++ /c++ -DOMIT_JSON_SUPPORT /g' build.sh && \
+    sed -i 's|^c++ |c++ -I../../ext |g' build.sh && \
     sh ./build.sh && ./mkworld && mv ./world.bin /var/lib/zerotier-one/planet && \
     apk del curl g++ && rm -rf /var/cache/apk/* && rm -rf /root/.cache && rm -rf /tmp/*
 

--- a/docker/zerotier/Dockerfile
+++ b/docker/zerotier/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache curl g++ && \
     sed -i '85i roots.push_back(World::Root());' ./mkworld.cpp && \
     sed -i '86i roots.back().identity = Identity(\"'"$identity"'\");' ./mkworld.cpp && \
     sed -i '87i roots.back().stableEndpoints.push_back(InetAddress(\"'"$addr"'\"));' ./mkworld.cpp && \
+    sed -i 's/c++ /c++ -DOMIT_JSON_SUPPORT /g' build.sh && \
     sh ./build.sh && ./mkworld && mv ./world.bin /var/lib/zerotier-one/planet && \
     apk del curl g++ && rm -rf /var/cache/apk/* && rm -rf /root/.cache && rm -rf /tmp/*
 


### PR DESCRIPTION
修正在 1.10.0 下 build.sh 出错的问题，具体信息如下：

```txt
In file included from ../../osdep/OSUtils.cpp:44:
../../osdep/OSUtils.hpp:46:10: fatal error: nlohmann/json.hpp: No such file or directory
   46 | #include <nlohmann/json.hpp>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from mkworld.cpp:49:
../../osdep/OSUtils.hpp:46:10: fatal error: nlohmann/json.hpp: No such file or directory
   46 | #include <nlohmann/json.hpp>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```